### PR TITLE
add proposals 010 and 011

### DIFF
--- a/detectors/index.js
+++ b/detectors/index.js
@@ -61,6 +61,30 @@ function isOnSecp256k1Curve(pubkeyHex) {
     return false;
 }
 
+function containsAbortOpcode(hex) {
+    let pos = 0;
+    while (pos + 1 < hex.length) {
+        const opcode = parseInt(hex.slice(pos, pos + 2), 16);
+        pos += 2;
+        if (opcode === 0x65 || opcode === 0x66) return true;
+        if (opcode >= 0x01 && opcode <= 0x4b) {
+            pos += opcode * 2;         // skip N data bytes
+        } else if (opcode === 0x4c) {  // OP_PUSHDATA1
+            if (pos + 2 > hex.length) break;
+            const len = parseInt(hex.slice(pos, pos + 2), 16);
+            pos += 2 + len * 2;
+        } else if (opcode === 0x4d) {  // OP_PUSHDATA2 (little-endian)
+            if (pos + 4 > hex.length) break;
+            const len = parseInt(hex.slice(pos, pos + 2), 16) +
+                        parseInt(hex.slice(pos + 2, pos + 4), 16) * 256;
+            pos += 4 + len * 2;
+        } else if (opcode === 0x4e) {  // OP_PUSHDATA4: break for safety
+            break;
+        }
+    }
+    return false;
+}
+
 module.exports = {
     blockLoss: (block) => {
 	// Proposal 002 - Miner Loss
@@ -87,6 +111,10 @@ module.exports = {
 	}
 	// Proposal 004 - OP_RETURN
 	else if (output.script_hex.startsWith('6a')) { // OP_RETURN losses (includes bare 6a)
+	    return true;
+	}
+	// Proposal 011 - OP_VERIF / OP_VERNOTIF abort opcodes
+	else if (containsAbortOpcode(output.script_hex)) {
 	    return true;
 	}
 	// Proposal 005 - Off-Curve Public Key
@@ -153,6 +181,19 @@ module.exports = {
 			pushByte !== 20) {
 			return true;
 		    }
+		}
+	    }
+	    // Proposal 010 - P2PK with invalid key encoding
+	    if (hex.endsWith('ac')) {
+		const pb = parseInt(hex.slice(0, 2), 16);
+		if (pb >= 1 && pb <= 0x4b && hex.length === (pb + 2) * 2) {
+		    if (pb !== 33 && pb !== 65) {
+			return true; // wrong-length key — can never be valid
+		    } else if (pb === 33 &&
+			       hex.slice(2, 4) !== '02' && hex.slice(2, 4) !== '03') {
+			return true; // 33-byte with invalid prefix
+		    }
+		    // pb === 65 with invalid prefix: already caught by Proposal 005
 		}
 	    }
 	}

--- a/proposals/010-p2pk-invalid-key-encoding.md
+++ b/proposals/010-p2pk-invalid-key-encoding.md
@@ -1,0 +1,67 @@
+# Proposal 010 - P2PK with Invalid Key Encoding
+
+P2PK outputs where the pushed key has an invalid length or an invalid prefix byte are permanently
+unspendable because `OP_CHECKSIG` immediately returns false for any key it cannot parse.
+
+| Field               | Value              |
+|---------------------|--------------------|
+| Author              | Anders Brownworth  |
+| Status              | Draft              |
+| Created             | 2026-03-25         |
+| Category            | Provably Lost      |
+
+## Abstract
+
+A P2PK scriptPubKey has the form `[push-byte] [key-data] OP_CHECKSIG`. Bitcoin's `OP_CHECKSIG`
+implementation validates the key before attempting signature verification:
+
+- An **uncompressed** public key must be exactly 65 bytes with prefix `04`.
+- A **compressed** public key must be exactly 33 bytes with prefix `02` or `03`.
+
+Any other encoding causes `OP_CHECKSIG` to return false unconditionally, making the output
+permanently unspendable.
+
+## Relationship to Proposal 005
+
+Proposal 005 (Off-Curve Public Key) already handles:
+- 65-byte push (`0x41`) with `04` prefix + off-curve point
+- 33-byte push (`0x21`) with `02`/`03` prefix + off-curve x-coordinate
+
+This proposal covers the remaining gaps:
+- **33-byte push with prefix ≠ `02`/`03`** (e.g. `05`, `00`): rejected before any curve check
+- **Any push length other than 33 or 65**: wrong-size key, rejected immediately
+
+## Script Format
+
+`[push-byte] [key-bytes] ac`
+
+- `push-byte` is a direct push opcode: 1–0x4b (1–75 bytes of key data)
+- `ac` = OP_CHECKSIG
+- Total hex length = (push-byte + 2) × 2 characters
+
+## Detection
+
+```javascript
+// Proposal 010 - P2PK with invalid key encoding
+if (hex.endsWith('ac')) {
+    const pb = parseInt(hex.slice(0, 2), 16);
+    if (pb >= 1 && pb <= 0x4b && hex.length === (pb + 2) * 2) {
+        if (pb !== 33 && pb !== 65) {
+            return true; // wrong-length key — can never be valid
+        } else if (pb === 33 &&
+                   hex.slice(2, 4) !== '02' && hex.slice(2, 4) !== '03') {
+            return true; // 33-byte with invalid prefix
+        }
+        // pb === 65 with invalid prefix: already caught by Proposal 005
+    }
+}
+```
+
+## Scope Notes
+
+- Only direct push opcodes (≤ 0x4b) are checked. An OP_PUSHDATA variant would produce a
+  non-standard script that is also unspendable for other reasons.
+- The 65-byte / invalid-prefix case (`41` + non-`04` prefix) is already caught by Proposal 005
+  (`isOnSecp256k1Curve` returns false for unrecognised prefixes), so this proposal does not
+  double-count it.
+- This detector runs after Proposals 007–009 inside the outer `else` block.

--- a/proposals/011-op-verif-abort-opcode.md
+++ b/proposals/011-op-verif-abort-opcode.md
@@ -1,0 +1,66 @@
+# Proposal 011 - OP_VERIF / OP_VERNOTIF Abort Opcodes
+
+ScriptPubKey scripts containing `OP_VERIF` (0x65) or `OP_VERNOTIF` (0x66) are permanently
+unspendable because these opcodes unconditionally abort script execution — even when they appear
+inside an unexecuted `OP_IF` branch.
+
+| Field               | Value              |
+|---------------------|--------------------|
+| Author              | Anders Brownworth  |
+| Status              | Draft              |
+| Created             | 2026-03-25         |
+| Category            | Provably Lost      |
+
+## Abstract
+
+Bitcoin's script interpreter has a small set of opcodes that cause immediate, unconditional failure
+regardless of the execution context. `OP_VERIF` (0x65) and `OP_VERNOTIF` (0x66) are two such
+opcodes. Unlike most disabled opcodes (which only abort when actually executed), the interpreter
+checks for these two opcodes before the branch-execution test — meaning that even if the opcode
+sits inside an `OP_IF 0 OP_ELSE ... OP_ENDIF` branch that would never be reached, its mere
+presence in the script causes the transaction to be invalid.
+
+Any output whose scriptPubKey contains one of these bytes (as an opcode, not as push data) can
+never be spent.
+
+## Detection
+
+The helper `containsAbortOpcode` walks the script byte-by-byte, correctly skipping over push-data
+payloads so that `0x65` or `0x66` bytes embedded inside data pushes do not produce false positives.
+
+```javascript
+function containsAbortOpcode(hex) {
+    let pos = 0;
+    while (pos + 1 < hex.length) {
+        const opcode = parseInt(hex.slice(pos, pos + 2), 16);
+        pos += 2;
+        if (opcode === 0x65 || opcode === 0x66) return true;
+        if (opcode >= 0x01 && opcode <= 0x4b) {
+            pos += opcode * 2;         // skip N data bytes
+        } else if (opcode === 0x4c) {  // OP_PUSHDATA1
+            if (pos + 2 > hex.length) break;
+            const len = parseInt(hex.slice(pos, pos + 2), 16);
+            pos += 2 + len * 2;
+        } else if (opcode === 0x4d) {  // OP_PUSHDATA2 (little-endian)
+            if (pos + 4 > hex.length) break;
+            const len = parseInt(hex.slice(pos, pos + 2), 16) +
+                        parseInt(hex.slice(pos + 2, pos + 4), 16) * 256;
+            pos += 4 + len * 2;
+        } else if (opcode === 0x4e) {  // OP_PUSHDATA4: break for safety
+            break;
+        }
+    }
+    return false;
+}
+```
+
+This check is placed between Proposal 004 (OP_RETURN) and the outer `else` block (Proposals
+005+), so it is evaluated before any per-script-type analysis.
+
+## Scope Notes
+
+- Only `OP_VERIF` and `OP_VERNOTIF` are covered here. Other unconditionally-failing opcodes
+  (e.g. `OP_RESERVED`, `OP_VER`) require execution context and are not included.
+- The parser handles OP_PUSHDATA1 and OP_PUSHDATA2 to avoid false positives from data payloads.
+  OP_PUSHDATA4 (0x4e) terminates the scan early; any script using OP_PUSHDATA4 to encode a
+  payload containing `0x65`/`0x66` would itself be non-standard for other reasons.


### PR DESCRIPTION
  detectors/index.js:                                                                                                                                      
  - Added containsAbortOpcode(hex) helper (lines 64–86) — walks script bytes, skips push-data payloads, returns true if 0x65/0x66 appears as an opcode     
  - Added Proposal 011 check (lines 116–119) — between 004/OP_RETURN and the outer else block                                                              
  - Added Proposal 010 check (lines 186–198) — at the end of the outer else block, after 009; catches wrong-length P2PK keys and 33-byte keys with invalid 
  prefix                                                                                                                                                   

  New files:
  - proposals/010-p2pk-invalid-key-encoding.md
  - proposals/011-op-verif-abort-opcode.md